### PR TITLE
Changed hardcoded ports to "portnum"

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,13 @@ Add a block to your `~/.mycroft/mycroft.conf` file like this:
   "HomeAssistantSkill": {
     "host": "hass.mylan.net",
     "password": "mysupersecrethasspass",
+    "portnum":8123
     "ssl": true|false
   }
 ```
 
-NOTE: SSL support is currently secure as it does verify the cert.
+NOTE 1: portnum is for the port number you have Home Assistant running on. 8123 is default.
+NOTE 2: SSL support is currently secure as it does verify the cert.
 
 You will then need to restart mycroft.
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ Add a block to your `~/.mycroft/mycroft.conf` file like this:
   }
 ```
 
-NOTE 1: portnum is for the port number you have Home Assistant running on. 8123 is default.
-NOTE 2: SSL support is currently secure as it does verify the cert.
+NOTE: portnum is for the port number you have Home Assistant running on. 8123 is default.
+
+NOTE: SSL support is currently secure as it does verify the cert.
 
 You will then need to restart mycroft.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Add a block to your `~/.mycroft/mycroft.conf` file like this:
   "HomeAssistantSkill": {
     "host": "hass.mylan.net",
     "password": "mysupersecrethasspass",
-    "portnum":8123
+    "portnum":8123,
     "ssl": true|false
   }
 ```

--- a/__init__.py
+++ b/__init__.py
@@ -14,13 +14,13 @@ LOGGER = getLogger(__name__)
 
 
 class HomeAssistantClient(object):
-    def __init__(self, host, password, port=8123, ssl=False):
+    def __init__(self, host, password, portnum, ssl=False):
         self.ssl = ssl
         if self.ssl:
-            port = 443
-            self.url = "https://%s:%d" % (host, port)
+            portnum
+            self.url = "https://%s:%d" % (host, portnum)
         else:
-            self.url = "http://%s:%d" % (host, port)
+            self.url = "http://%s:%d" % (host, portnum)
         self.headers = {
             'x-ha-access': password,
             'Content-Type': 'application/json'
@@ -97,6 +97,7 @@ class HomeAssistantSkill(MycroftSkill):
         self.ha = HomeAssistantClient(
             self.config.get('host'),
             self.config.get('password'),
+            self.config.get('portnum'),
             ssl=self.config.get(
                 'ssl',
                 False))


### PR DESCRIPTION
This way we pass a port number though JSON (you have to set it, no fall back)

"HomeAssistantSkill":{
"host":"my.hass.address",
"password":"mypassword",
"portnum":8123,
"ssl":true
}

## Description:

**Related issue (if applicable):** fixes #<mycroft-homeassistant issue number goes here>


## Checklist:
  - [x] Travis is passing tests **Your PR cannot be merged unless tests pass**
  - [x] No PEP Bot Errors or Issues
