### PR TITLE
Catching errors and settingsmeta support

### DIFF
--- a/dialog/de/homeassistant.brightness.badreq.dialog
+++ b/dialog/de/homeassistant.brightness.badreq.dialog
@@ -1,0 +1,2 @@
+Bitte wählen sie eine Helligkeit zwischen 0 und 100
+Wie hell bitte? Sie können von 0 bis 100 wählen

--- a/dialog/de/homeassistant.device.toggle.dialog
+++ b/dialog/de/homeassistant.device.toggle.dialog
@@ -1,0 +1,1 @@
+{{dev_name}} wurde umgeschaltet

--- a/dialog/de/homeassistant.error.offline.dialog
+++ b/dialog/de/homeassistant.error.offline.dialog
@@ -1,0 +1,2 @@
+Der Homeassistant-Server scheint offline zu sein
+Der Homeassistant-Server ist nicht erreichbar

--- a/dialog/de/homeassistant.sensor.dialog
+++ b/dialog/de/homeassistant.sensor.dialog
@@ -1,0 +1,3 @@
+Aktuell ist {{dev_name}} auf {{value}} {{unit}}
+{{dev_name}} hat den Wert: {{value}} {{unit}}
+{{dev_name}} ist {{value}} {{unit}}

--- a/dialog/en-us/homeassistant.error.offline.dialog
+++ b/dialog/en-us/homeassistant.error.offline.dialog
@@ -1,0 +1,3 @@
+The Homeassistant server appears to be offline
+Couldn't reach the homeassistant server
+The homeassistant server did not respond

--- a/settingsmeta.json
+++ b/settingsmeta.json
@@ -26,7 +26,7 @@
                   },
                   {
                       "name": "ssl",
-                      "type": "bool",
+                      "type": "text",
                       "label": "ssl",
                       "value": ""
                   }

--- a/settingsmeta.json
+++ b/settingsmeta.json
@@ -20,7 +20,7 @@
                   },
                   {
                       "name": "portnum",
-                      "type": "int",
+                      "type": "Number",
                       "label": "portnum",
                       "value": ""
                   },


### PR DESCRIPTION
Catching a connection error when requesting from homeassistant, Mycroft now tells you that something is wrong.
Also the settings page on Mycroft Home should now appear directly after installing the skill.
Also added German language dialogs for new skills

## Description:

**Related issue (if applicable):** fixes #<mycroft-homeassistant issue number goes here>


## Checklist:
  - [x] Travis is passing tests **Your PR cannot be merged unless tests pass**
  - [x] No PEP Bot Errors or Issues
