### PR TITLE
Use token_sort_ratio so that entity matches are more specific

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -46,7 +46,7 @@ class HomeAssistantClient(object):
                         # something like temperature outside
                         # should score on "outside temperature sensor"
                         # and repetitions should not count on my behalf
-                        score = fuzz.token_set_ratio(
+                        score = fuzz.token_sort_ratio(
                             entity,
                             state['attributes']['friendly_name'].lower())
                         if score > best_score:
@@ -56,7 +56,7 @@ class HomeAssistantClient(object):
                                 "dev_name": state['attributes']
                                 ['friendly_name'],
                                 "state": state['state']}
-                        score = fuzz.token_set_ratio(
+                        score = fuzz.token_sort_ratio(
                             entity,
                             state['entity_id'].lower())
                         if score > best_score:


### PR DESCRIPTION
## Description:
Using token_set_ratio caused issues when an entity name contains
the group name string. In these cases token_sort_ratio seems to
give more specific results-

>>> fuzz.token_set_ratio("bedroom", "bedroom ambient light")
100
>>> fuzz.token_set_ratio("bedroom ambient light", "bedroom ambient light")
100
>>> fuzz.token_sort_ratio("bedroom ", "bedroom ambient light")
50
>>> fuzz.token_sort_ratio("bedroom ambient light", "bedroom ambient light")
100

## Checklist:
  - [ ] Travis is passing tests **Your PR cannot be merged unless tests pass**
  - [ ] No PEP Bot Errors or Issues
