### PR TITLE
Fix talking about unknown entities and enable use of conversation component as fallback

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -92,7 +92,7 @@ class HomeAssistantClient(object):
                             unit_measur = entity_attrs['unit_of_measurement']
                     except KeyError:
                         unit_measur = None
-                    # IDEA: return the color if available => allow changing
+                    # IDEA: return the color if available
                     # TODO: change to return the whole attr dictionary =>
                     # free use within handle methods
                     sensor_name = entity_attrs['friendly_name']
@@ -111,6 +111,7 @@ class HomeAssistantClient(object):
 
 
 class HomeAssistantSkill(MycroftSkill):
+
     def __init__(self):
         super(HomeAssistantSkill, self).__init__(name="HomeAssistantSkill")
         self.ha = None
@@ -423,7 +424,7 @@ class HomeAssistantSkill(MycroftSkill):
             return
         if ha_entity is None:
             self.speak_dialog('homeassistant.device.unknown', data={
-                              "dev_name": ha_entity['dev_name']})
+                              "dev_name": entity})
             return
 
         entity = ha_entity['id']

--- a/__init__.py
+++ b/__init__.py
@@ -36,7 +36,7 @@ class HomeAssistantClient(object):
         if self.ssl:
             req = get("%s/api/states" %
                       self.url, headers=self.headers,
-                       verify=self.verify, timeout=TIMEOUT)
+                      verify=self.verify, timeout=TIMEOUT)
         else:
             req = get("%s/api/states" % self.url, headers=self.headers,
                       timeout=TIMEOUT)
@@ -180,9 +180,9 @@ class HomeAssistantSkill(FallbackSkill):
                 self.settings.get('verify') == 'true'
                 )
             if self.ha:
-            # Check if conversation component is loaded at HA-server
-            # and activate fallback accordingly (ha-server/api/components)
-            # TODO: enable other tools like dialogflow
+                # Check if conversation component is loaded at HA-server
+                # and activate fallback accordingly (ha-server/api/components)
+                # TODO: enable other tools like dialogflow
                 if (self.ha.find_component('conversation') and
                    self.settings.get('enable_fallback') == 'true'):
                     self.enable_fallback = True

--- a/settingsmeta.json
+++ b/settingsmeta.json
@@ -40,6 +40,12 @@
                       "type": "checkbox",
                       "label": "Verify SSL Certificate",
                       "value": "true"
+                  },
+                  {
+                      "name": "enable_fallback",
+                      "type": "checkbox",
+                      "label": "Enable conversation component as fallback",
+                      "value": "true"
                   }
               ]
           }


### PR DESCRIPTION
Enabling the use of the [conversation](https://www.home-assistant.io/components/conversation/) component as fallback. 

Also includes fix:
When None is returned for an entity now mycroft repeats what he has
understood for sensors too (instead of crashing)


## Checklist:
  - [ ] Travis is passing tests **Your PR cannot be merged unless tests pass**
  - [x] No PEP Bot Errors or Issues
