### PR TITLE
Handle wrong setup settings on init

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -48,16 +48,13 @@ class HomeAssistantSkill(FallbackSkill):
                 self.settings.get('ssl') == 'true',
                 self.settings.get('verify') == 'true'
             )
-            if self.ha:
+            if self.ha.connected():
                 # Check if conversation component is loaded at HA-server
                 # and activate fallback accordingly (ha-server/api/components)
                 # TODO: enable other tools like dialogflow
-                try:
-                    conversation_activated = self.ha.find_component(
-                        'conversation'
-                    )
-                except (ConnectionError, RequestException):
-                    conversation_activated = False
+                conversation_activated = self.ha.find_component(
+                    'conversation'
+                )
                 if conversation_activated:
                     self.enable_fallback = \
                         self.settings.get('enable_fallback') == 'true'

--- a/ha_client.py
+++ b/ha_client.py
@@ -1,6 +1,8 @@
 from requests import get, post
 from fuzzywuzzy import fuzz
 import json
+from requests.exceptions import Timeout, RequestException
+
 
 __author__ = 'btotharye'
 
@@ -39,6 +41,13 @@ class HomeAssistantClient(object):
                       timeout=TIMEOUT)
         req.raise_for_status()
         return req.json()
+
+    def connected(self):
+        try:
+            self._get_state()
+            return True
+        except (Timeout, ConnectionError, RequestException):
+            return False
 
     def find_entity(self, entity, types):
         """Find entity with specified name, fuzzy matching


### PR DESCRIPTION
## Description:
If setting are invalid, mycroft would not load home assistant at all because an error occurs when accessing the find_component method. This is handled now with an additional connected method


## Checklist:
  - [x] Code is Python 3.x compatible
  - [x] Travis is passing tests **Your PR cannot be merged unless tests pass**
  - [x] No PEP Bot Errors or Issues
