### PR TITLE
Added 'Bearer ' to HTTP-Authorization-Header

### DIFF
--- a/ha_client.py
+++ b/ha_client.py
@@ -22,7 +22,7 @@ class HomeAssistantClient(object):
         if portnum:
             self.url = "{}:{}".format(self.url, portnum)
         self.headers = {
-            'Authorization': token,
+            'Authorization': "Bearer {}".format(token),
             'Content-Type': 'application/json'
         }
 


### PR DESCRIPTION
## Description:
According to the Home Assistant 0.79-Docs the indicator "Bearer " needs to be added in front of the actual token (see https://developers.home-assistant.io/docs/en/auth_api.html#example-python).

Tested & required by my combination of Home Assistant 0.79.3 and mycroft-core: 18.8.2.

WARNING: Due to my current versions I have not tested if this commit breaks the authorization-process on earlier versions. 

**Related issue (if applicable): failed authorization if the indicator is not present.


## Checklist:
  - [ ] Test if commit breaks earlier versions (< HA 0.79.3 and < mycroft-core 18.8.2)
  - [ ] Code is Python 3.x compatible
  - [ ] Travis is passing tests **Your PR cannot be merged unless tests pass**
  - [x] No PEP Bot Errors or Issues
